### PR TITLE
Update confidential.fsh

### DIFF
--- a/input/fsh/confidential.fsh
+++ b/input/fsh/confidential.fsh
@@ -3,6 +3,15 @@ InstanceOf: DkCorePatient
 Title: "Example of a patient with confidential adress and name"
 Description: "Example of a patient with confidential adress and name"
 Usage: #example
+* text[0].div = """<div xmlns="http://www.w3.org/1999/xhtml">
+
+This instance is an example of a Danish citizen who has requested name and address protection (Navne- og adressebeskyttelse), why the instance is marked with a security label. 
+Only personnel using systems in public/official affairs are allowed to see name and address for the citizen, why these information are included in the profile.
+
+<p><b>Generated Narrative</b></p><div style="display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%"><p style="margin-bottom: 0px">Resource "Confidential" </p><p style="margin-bottom: 0px">Profile: <a href="StructureDefinition-dk-core-patient.html">Danish Core Patient Profile</a></p><p style="margin-bottom: 0px">Security Labels: <span title="{http://terminology.hl7.org/CodeSystem/v3-Confidentiality http://terminology.hl7.org/CodeSystem/v3-Confidentiality}">http://terminology.hl7.org/CodeSystem/v3-Confidentiality</span></p></div><p><b>identifier</b>: id: 0908760405</p><p><b>name</b>: Hans Hansen (OFFICIAL)</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 1976-08-09</p><p><b>address</b>: Julianevej 22 6000 Kolding (HOME)</p>
+</div>
+"""
+* text[0].status = #additional
 * meta.security.system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * meta.security.code = #R 
 * meta.security.display = "restricted"


### PR DESCRIPTION
#47
Added descriptive text about the instance.

I understand from this topic (https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/.E2.9C.94.20Narratives.20in.20instances) that one must include the line with "Generated Narrative", otherwise it want be shown. Therefore is the description and the "Generated Narrative" included in this way.