### PR TITLE
A few errors from QA-report handled

### DIFF
--- a/input/fsh/DkCoreEncounter.fsh
+++ b/input/fsh/DkCoreEncounter.fsh
@@ -26,7 +26,7 @@ Usage: #example
 * extension[+].url = "http://hl7.dk/fhir/core/StructureDefinition/dk-core-care-provider"
 * extension[=].valueReference.reference = "Organization/19f9ee18-7677-4caf-88fe-8f6df2f2906e"
 * status = #in-progress
-* class.system = "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+* class.system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"
 * class.code = #IMP
 * subject.reference = "Patient/283"
 * period.start = "2025-11-14T08:50:00.0000+01:00"
@@ -40,13 +40,13 @@ Usage: #example
 * extension[0].url = "http://hl7.dk/fhir/core/StructureDefinition/dk-core-care-provider"
 * extension[=].valueReference.reference = "Organization/19f9ee18-7677-4caf-88fe-8f6df2f2906e"
 * status = #finished
-* class.system = "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+* class.system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"
 * class.code = #IMP
-* subject.reference = "Patient/John"
+* subject.reference = "Patient/john"
 * period.start = "2022-04-27T08:50:00.0000+01:00"
 * period.end = "2022-04-28T14:00:00.0000+01:00"
 * diagnosis[0].condition.reference = "Condition/JohnFracture"
 * diagnosis[=].rank = 1
-* diagnosis[+].condition.reference = "Codition/JohnDiabetes"
+* diagnosis[+].condition.reference = "Condition/JohnDiabetes"
 * diagnosis[=].rank = 2
 * serviceProvider.reference = "Organization/8510eec9-180b-4e9c-95b6-02fad9f853d3"

--- a/input/fsh/DkCoreMinimalDocumentReference.fsh
+++ b/input/fsh/DkCoreMinimalDocumentReference.fsh
@@ -7,7 +7,7 @@ Description: "HL7 Denmark core profile for a Minimal DocumentReference inherited
 * extension[versionid] ^short = "Specifies the version of the DocumentReference profile for a standard."
 * context.facilityType from SorOrganizationType (extensible)
 * context.practiceSetting from SorPracticeSettingCode (extensible)
-* context.event from $v3-ActCode3.0.0 
+* context.event from $v3-ActCode3.0.0 (example)
 * author 1..*
 * author only Reference(DkCorePatient or DkCorePractitioner or DkCorePractitionerRole or DkCoreRelatedPerson or DkCoreOrganization or Device)
 * authenticator only Reference(DkCorePractitioner or DkCorePractitionerRole or DkCoreOrganization)
@@ -42,7 +42,7 @@ Description: "APD-DK DocumentReference instance of DkCoreMinimalDocumentReferenc
 * content.format = $MedComFormatOID#urn:ad:dk:medcom:apd-v2.0.1:full "DK APD schema"
 * context.event = $SKS#ALAL03 "Psykiske lidelser og adfærdsmæssige forstyrrelser"
 * context.sourcePatientInfo = Reference(37628912-7816-47a3-acd8-396b610be142)
-* context.facilityType = $sct#554871000005105 "psykiatrienhed"
+* context.facilityType = $sct#554871000005105 "psykiatri"
 * context.practiceSetting = $sct#394588006 "børne- og ungdomspsykiatri"
 * extension[+].url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-DocumentReference.version"
 * extension[=].valueString = "1.0.0"

--- a/input/pagecontent/StructureDefinition-dk-core-encounter-intro.md
+++ b/input/pagecontent/StructureDefinition-dk-core-encounter-intro.md
@@ -11,7 +11,7 @@ The treatment responsibility is represented by Encounter.serviceProvider and the
 extension [CareProvider](./StructureDefinition-dk-core-care-provider.html).
 
 ### Specifying diagnosis
-It is preferred, that the [Danish Core Condition](./StructureDefinition-dk-core-condition-intro.md) is used when referencing diagnosis in a
+It is preferred, that the [Danish Core Condition](./StructureDefinition-dk-core-condition.html) is used when referencing diagnosis in a
 Danish context.
 
 Hospital encounters in Denmark have diagnosis associated that specifies the primary diagnosis beeing treated ([DA] aktionsdiagnose) and


### PR DESCRIPTION
Handled a few errors in the QA-report. As agreed upon at the HL7-DK meeting, the binding strength on DocumentReference.context.event is changed to example.