### PR TITLE
removing deprecated content

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -6,7 +6,6 @@ Alias: $condition-category = http://terminology.hl7.org/CodeSystem/condition-cat
 Alias: $condition-ver-status = http://terminology.hl7.org/CodeSystem/condition-ver-status
 Alias: $v2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
 Alias: $dk-core-municipality-codes = http://hl7.dk/fhir/core/CodeSystem/dk-core-municipality-codes
-Alias: $dk-core-regional-subdivision-codes = http://hl7.dk/fhir/core/CodeSystem/dk-core-regional-subdivision-codes
 Alias: $iso3166-2 = urn:iso:std:iso:3166:-2
 Alias: $v3-MaritalStatus = http://terminology.hl7.org/CodeSystem/v3-MaritalStatus
 Alias: $dk-marital-status = http://hl7.dk/fhir/core/CodeSystem/dk-marital-status

--- a/input/fsh/codeSystems.fsh
+++ b/input/fsh/codeSystems.fsh
@@ -428,29 +428,6 @@ Description: "Municipality codes as defined by https://danmarksadresser.dk/adres
   * ^designation.language = #da
   * ^designation.value = "Vejle"
 
-CodeSystem: DKCoreRegionalSubdivisionCodes
-Title: "DK Regional Subdivision Codes"
-Id: dk-core-regional-subdivision-codes
-Description: "Subdivision codes (Regional codes) used in Denmark as found on https://www.iso.org/obp/ui/#iso:code:3166:DK"
-* ^experimental = false
-* ^caseSensitive = false
-* ^content = #complete
-* #DK-84 "Capital Region of Denmark"
-  * ^designation.language = #da
-  * ^designation.value = "Hovedstaden"
-* #DK-82 "Central Denmark Region"
-  * ^designation.language = #da
-  * ^designation.value = "Midtjylland"
-* #DK-81 "Nord Denmark Region"
-  * ^designation.language = #da
-  * ^designation.value = "Nordjylland"
-* #DK-85 "Region Zealand"
-  * ^designation.language = #da
-  * ^designation.value = "Sjælland"
-* #DK-83 "Region of Southern Denmark"
-  * ^designation.language = #da
-  * ^designation.value = "Syddanmark"
-
 CodeSystem: DK_Marital_Status_Codes
 Id: dk-marital-status
 Title: "DK Marital Statuses"

--- a/input/fsh/valueSets.fsh
+++ b/input/fsh/valueSets.fsh
@@ -354,13 +354,6 @@ Description: "DK Related Person Relationship Types"
 // * include codes from system MunicipalityCodes
 // * include codes from system GreenlandMunicipalityCodes
 
-// ValueSet: RegionalSubdivisionCodes
-// Id: dk-core-RegionalSubDivisionCodes
-// Title: "DK Regional Subdivision Codes"
-// Description: "Subdivision codes (Regional codes) used in Denmark"
-// * ^experimental = false
-// * include codes from system DKCoreRegionalSubdivisionCodes
-
 // ValueSet: LoincBasicObservation
 // Id: dk-core-LoincBasicObservation
 // Title: "DK Core LOINC Basic Observations"


### PR DESCRIPTION
This pull request removes the regional subdivision codes (regional codes for Denmark) from the codebase. The main changes include deleting the related code system definition, its alias, and the value set that referenced it.

**Removal of Danish regional subdivision codes:**

* Deleted the `DKCoreRegionalSubdivisionCodes` code system definition from `codeSystems.fsh`, including all regional codes and their Danish designations.
* Removed the alias `$dk-core-regional-subdivision-codes` from `aliases.fsh`.
* Removed the (commented out) `RegionalSubdivisionCodes` value set definition from `valueSets.fsh`.